### PR TITLE
fix: replace 11 bare excepts with except Exception across 4 files

### DIFF
--- a/align_ges.py
+++ b/align_ges.py
@@ -21,12 +21,12 @@ def extract_reference_frames(video_path, num_frames=1, output_dir="reference_fra
     cmd = f"ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 {video_path}"
     try:
         frame_count = int(subprocess.check_output(cmd, shell=True).decode('utf-8').strip())
-    except:
+    except Exception:
         # Fallback method
         cmd = f"ffprobe -v error -select_streams v:0 -show_entries stream=nb_frames -of csv=p=0 {video_path}"
         try:
             frame_count = int(subprocess.check_output(cmd, shell=True).decode('utf-8').strip())
-        except:
+        except Exception:
             print("Warning: Could not determine frame count, assuming 240 frames")
             frame_count = 240
     

--- a/gaussian_renderer/__init__.py
+++ b/gaussian_renderer/__init__.py
@@ -27,7 +27,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
     screenspace_points = torch.zeros_like(pc.get_xyz, dtype=pc.get_xyz.dtype, requires_grad=True, device="cuda") + 0
     try:
         screenspace_points.retain_grad()
-    except:
+    except Exception:
         pass
 
     # Set up rasterization configuration
@@ -86,7 +86,7 @@ def render(viewpoint_camera, pc : GaussianModel, pipe, bg_color : torch.Tensor, 
                     embedding = pc.appearance_embeddings[viewpoint_camera.uid]
                     # print("Use embedding from camera", viewpoint_camera.uid)
                     # embedding = pc.appearance_embeddings[5]
-                except:
+                except Exception:
                     print(pc.appearance_embeddings.shape)
                     print('Embedding not found for camera', viewpoint_camera.uid, 'use mean embedding instead')
                     with torch.no_grad():  # important to avoid no needed gradients

--- a/sat_utils.py
+++ b/sat_utils.py
@@ -162,7 +162,7 @@ def dsm_pointwise_diff(in_dsm_path, gt_dsm_path, dsm_metadata, gt_mask_path=None
     fix_xy = False
     try:
         import dsmr
-    except:
+    except Exception:
         print("Warning: dsmr not found ! DSM registration will only use the Z dimension")
         fix_xy = True
     if fix_xy:

--- a/scene/dataset_readers.py
+++ b/scene/dataset_readers.py
@@ -154,7 +154,7 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
         cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.bin")
         cam_extrinsics = read_extrinsics_binary(cameras_extrinsic_file)
         cam_intrinsics = read_intrinsics_binary(cameras_intrinsic_file)
-    except:
+    except Exception:
         cameras_extrinsic_file = os.path.join(path, "sparse/0", "images.txt")
         cameras_intrinsic_file = os.path.join(path, "sparse/0", "cameras.txt")
         cam_extrinsics = read_extrinsics_text(cameras_extrinsic_file)
@@ -180,12 +180,12 @@ def readColmapSceneInfo(path, images, eval, llffhold=8):
         print("Converting point3d.bin to .ply, will happen only the first time you open the scene.")
         try:
             xyz, rgb, _ = read_points3D_binary(bin_path)
-        except:
+        except Exception:
             xyz, rgb, _ = read_points3D_text(txt_path)
         storePly(ply_path, xyz, rgb)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,
@@ -263,7 +263,7 @@ def readNerfSyntheticInfo(path, white_background, eval, extension=".png"):
         storePly(ply_path, xyz, SH2RGB(shs) * 255)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,
@@ -347,7 +347,7 @@ def readMultiScaleNerfSyntheticInfo(path, white_background, eval, load_allres=Fa
         storePly(ply_path, xyz, SH2RGB(shs) * 255)
     try:
         pcd = fetchPly(ply_path)
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,
@@ -481,7 +481,7 @@ def readSatelliteInfo(path, white_background, eval, extension=".png"):
         pcd = fetchPly(ply_path)
         # print number of points
         print(f"Number of points in the point cloud: {len(pcd.points)}")
-    except:
+    except Exception:
         pcd = None
 
     scene_info = SceneInfo(point_cloud=pcd,


### PR DESCRIPTION
Replace bare `except:` with `except Exception:` across 4 files (11 sites).

**Why:** Bare `except:` catches `BaseException` including `KeyboardInterrupt`/`SystemExit`. `except Exception:` preserves fallback behavior.

**Files:** `align_ges.py` (2), `gaussian_renderer/__init__.py` (2), `sat_utils.py` (1), `scene/dataset_readers.py` (6)